### PR TITLE
updated mod to MC 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Death Coords
+
+## Download
+Mod jar files can be downloaded at curseforge:  
+https://www.curseforge.com/minecraft/mc-mods/death-coords
+
+## Description
 Death Coords is a simple client side mod that displays your death coordinates on the respawn screen.  
 When the player respawns their death coordinates will also be displayed in the chat in a gold color.

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '1.7-SNAPSHOT'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_21
+targetCompatibility = JavaVersion.VERSION_21
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -46,8 +46,8 @@ tasks.withType(JavaCompile).configureEach {
 	// If Javadoc is generated, this must be specified in that task too.
 	it.options.encoding = "UTF-8"
 
-	// Minecraft 1.17 (21w19a) upwards uses Java 16.
-	it.options.release = 16
+	// Minecraft 1.21 upwards uses Java 21.
+	it.options.release = 21
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,14 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.17.1
-	yarn_mappings=1.17.1+build.14
-	loader_version=0.11.6
+	minecraft_version=1.21
+	yarn_mappings=1.21+build.7
+	loader_version=0.15.11
 
 # Mod Properties
 	mod_version = 1.0.0
 	maven_group = com.loucaskreger.deathcoords
-	archives_base_name = fabric-death-coords-1.17.1
+	archives_base_name = fabric-death-coords-1.21
 
 # Dependencies
-	fabric_version=0.37.0+1.17
+	fabric_version=0.100.4+1.21

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/loucaskreger/deathcoords/DeathCoords.java
+++ b/src/main/java/com/loucaskreger/deathcoords/DeathCoords.java
@@ -1,13 +1,28 @@
 package com.loucaskreger.deathcoords;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import net.fabricmc.api.ModInitializer;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.world.World;
 
 public class DeathCoords implements ModInitializer {
 
-    public static String deathCoords = "";
+	private static final Map<RegistryIdPair, String> WORLD_KEY_TO_NAME = new HashMap<>();
 
-    @Override
-    public void onInitialize() {
+	@Override
+	public void onInitialize() {
+		WORLD_KEY_TO_NAME.put(new RegistryIdPair(World.OVERWORLD), "Overworld");
+		WORLD_KEY_TO_NAME.put(new RegistryIdPair(World.NETHER), "Nether");
+		WORLD_KEY_TO_NAME.put(new RegistryIdPair(World.END), "End");
+	}
 
-    }
+	public static String BuildDeathCoordsMessage(ClientPlayerEntity player) {
+		var pos = player.getPos();
+		var dimKey = player.getWorld().getRegistryKey();
+		var dimensionName = WORLD_KEY_TO_NAME.getOrDefault(new RegistryIdPair(dimKey), "Unknown");
+		var text = String.format("You died at X: %.2f, Y: %.2f, Z: %.2f in the %s.", pos.x, pos.y, pos.z, dimensionName);
+		return text;
+	}
 }

--- a/src/main/java/com/loucaskreger/deathcoords/RegistryIdPair.java
+++ b/src/main/java/com/loucaskreger/deathcoords/RegistryIdPair.java
@@ -1,0 +1,10 @@
+package com.loucaskreger.deathcoords;
+
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.util.Identifier;
+
+public record RegistryIdPair(Identifier registry, Identifier id) {
+	public RegistryIdPair(RegistryKey<?> registryKey) {
+		this(registryKey.getRegistry(), registryKey.getValue());
+	}
+}

--- a/src/main/java/com/loucaskreger/deathcoords/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/com/loucaskreger/deathcoords/mixin/ClientPlayerEntityMixin.java
@@ -1,24 +1,27 @@
 package com.loucaskreger.deathcoords.mixin;
 
-import com.loucaskreger.deathcoords.DeathCoords;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.text.LiteralText;
-import net.minecraft.util.Formatting;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.loucaskreger.deathcoords.DeathCoords;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
 @Mixin(ClientPlayerEntity.class)
 public class ClientPlayerEntityMixin {
 
-    @Inject(method = "requestRespawn", at = @At("TAIL"))
-    public void requestRespawn(CallbackInfo ci) {
-        var client = MinecraftClient.getInstance();
-        var deathCoordsLiteral = new LiteralText(DeathCoords.deathCoords);
-        deathCoordsLiteral.setStyle(deathCoordsLiteral.getStyle().withColor(Formatting.GOLD));
-        client.player.sendMessage(deathCoordsLiteral, false);
-        DeathCoords.deathCoords = "";
-    }
+	@Inject(method = "requestRespawn", at = @At("TAIL"))
+	public void requestRespawn(CallbackInfo ci) {
+		var client = MinecraftClient.getInstance();
+
+		var text = DeathCoords.BuildDeathCoordsMessage(client.player);
+		var deathCoordsLiteral = Text.literal(text);
+		deathCoordsLiteral.setStyle(deathCoordsLiteral.getStyle().withColor(Formatting.GOLD));
+		client.player.sendMessage(deathCoordsLiteral, false);
+	}
 }

--- a/src/main/java/com/loucaskreger/deathcoords/mixin/DeathScreenMixin.java
+++ b/src/main/java/com/loucaskreger/deathcoords/mixin/DeathScreenMixin.java
@@ -1,38 +1,26 @@
 package com.loucaskreger.deathcoords.mixin;
 
-import com.loucaskreger.deathcoords.DeathCoords;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.DeathScreen;
-import net.minecraft.client.util.math.MatrixStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.loucaskreger.deathcoords.DeathCoords;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.DeathScreen;
+
 @Mixin(DeathScreen.class)
 public class DeathScreenMixin {
 
+	@Inject(method = "render", at = @At("TAIL"), cancellable = true)
+	private void onRender(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+		var client = MinecraftClient.getInstance();
+		var screen = (DeathScreen) (Object) this;
 
-    @Inject(method = "render", at = @At("TAIL"), cancellable = true)
-    private void onRender(MatrixStack matricies, int mouseX, int mouseY, float delta, CallbackInfo ci) {
-        var client = MinecraftClient.getInstance();
-        var screen = (DeathScreen) (Object) this;
-        var pos = client.player.getPos();
-        var dimType = client.world.getDimension();
-        String dimension = "";
-        if (!dimType.isBedWorking()) {
-            if (dimType.hasEnderDragonFight()) {
-                dimension = "End";
-            } else {
-                dimension = "Nether";
-            }
-        } else {
-            dimension = "Overworld";
-        }
-        var text = String.format("You died at X: %.2f, Y: %.2f, Z: %.2f in the %s.", pos.x, pos.y, pos.z, dimension);
-        DeathCoords.deathCoords = text;
-        client.textRenderer.drawWithShadow(matricies, text, (screen.width / 2) - (client.textRenderer.getWidth(text) / 2), 115, 0xFFFFFF);
-    }
-
+		var text = DeathCoords.BuildDeathCoordsMessage(client.player);
+		context.drawCenteredTextWithShadow(((ScreenAccessor) screen).getTextRenderer(), text, screen.width / 2, 115, 0xFFFFFF);
+	}
 
 }

--- a/src/main/java/com/loucaskreger/deathcoords/mixin/ScreenAccessor.java
+++ b/src/main/java/com/loucaskreger/deathcoords/mixin/ScreenAccessor.java
@@ -1,0 +1,13 @@
+package com.loucaskreger.deathcoords.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.screen.Screen;
+
+@Mixin(Screen.class)
+public interface ScreenAccessor {
+	@Accessor
+	TextRenderer getTextRenderer();
+}

--- a/src/main/resources/deathcoords.mixins.json
+++ b/src/main/resources/deathcoords.mixins.json
@@ -1,15 +1,16 @@
 {
-  "required": true,
-  "minVersion": "0.8",
-  "package": "com.loucaskreger.deathcoords.mixin",
-  "compatibilityLevel": "JAVA_16",
-  "mixins": [
-  ],
-  "client": [
-    "DeathScreenMixin",
-    "ClientPlayerEntityMixin"
-  ],
-  "injectors": {
-    "defaultRequire": 1
-  }
+	"required": true,
+	"minVersion": "0.8",
+	"package": "com.loucaskreger.deathcoords.mixin",
+	"compatibilityLevel": "JAVA_21",
+	"mixins": [
+	],
+	"client": [
+		"DeathScreenMixin",
+		"ClientPlayerEntityMixin",
+		"ScreenAccessor"
+	],
+	"injectors": {
+		"defaultRequire": 1
+	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,34 +1,32 @@
 {
-  "schemaVersion": 1,
-  "id": "deathcoords",
-  "version": "${version}",
-  "name": "Death Coords",
-  "description": "Displays your death coordinates on screen when you die",
-  "authors": [
-    "AreUThreateningMe"
-  ],
-  "contact": {
-    "homepage": "https://fabricmc.net/",
-    "sources": "https://github.com/FabricMC/fabric-example-mod"
-  },
-  "license": "CC0-1.0",
-  "icon": "assets/deathcoords/DeathCoordsLogo.png",
-  "environment": "*",
-  "entrypoints": {
-    "main": [
-      "com.loucaskreger.deathcoords.DeathCoords"
-    ]
-  },
-  "mixins": [
-    "deathcoords.mixins.json"
-  ],
-  "depends": {
-    "fabricloader": ">=0.11.3",
-    "fabric": "*",
-    "minecraft": "1.17.x",
-    "java": ">=16"
-  },
-  "suggests": {
-    "another-mod": "*"
-  }
+	"schemaVersion": 1,
+	"id": "deathcoords",
+	"version": "${version}",
+	"name": "Death Coords",
+	"description": "Displays your death coordinates on screen when you die",
+	"authors": [
+		"AreUThreateningMe",
+		"Klotzi111"
+	],
+	"contact": {
+		"homepage": "https://www.curseforge.com/minecraft/mc-mods/death-coords",
+		"sources": "https://github.com/kregerl/DeathCoords",
+		"issues": "https://github.com/kregerl/DeathCoords/issues"
+	},
+	"license": "CC0-1.0",
+	"icon": "assets/deathcoords/DeathCoordsLogo.png",
+	"environment": "*",
+	"entrypoints": {
+		"main": [
+			"com.loucaskreger.deathcoords.DeathCoords"
+		]
+	},
+	"mixins": [
+		"deathcoords.mixins.json"
+	],
+	"depends": {
+		"fabricloader": ">=0.11.3",
+		"minecraft": ">=1.21",
+		"java": ">=21"
+	}
 }


### PR DESCRIPTION
I like the simplicity of your mod and i wanted to use it in Minecraft 1.21 but it was not compatible.
So I made it compatible. Here you have it.
You might want to change the version number of the mod before publishing a new version to [curseforge](https://www.curseforge.com/minecraft/mc-mods/death-coords).


**Changes in this PR:**
Now using latest loom and yarn mappings and java 21.

Now also building the death coords text very time. This fixes the bug that no valid death coords message was send to the player when the player disconnected in the death screen and respawned after reconnecting.